### PR TITLE
catalogue (almost) fixed

### DIFF
--- a/base/src/main/java/org/giavacms/base/repository/PageRepository.java
+++ b/base/src/main/java/org/giavacms/base/repository/PageRepository.java
@@ -160,7 +160,7 @@ public class PageRepository
    {
       try
       {
-         StringBuffer sbq = new StringBuffer("select p.id, p.title from "
+         StringBuffer sbq = new StringBuffer("select p.id, p.title, p.template_id from "
                   + Page.TABLE_NAME + " p where p.clone = :CLONE and p.extension ");
          if (extension != null && extension.trim().length() > 0)
          {
@@ -170,7 +170,7 @@ public class PageRepository
          {
             sbq.append(" is null ");
          }
-         Query q = getEm().createQuery(sbq.toString()).setParameter("CLONE", false);
+         Query q = getEm().createNativeQuery(sbq.toString()).setParameter("CLONE", false);
          if (extension != null && extension.trim().length() > 0)
          {
             q.setParameter("EXTENSION", extension);
@@ -185,6 +185,7 @@ public class PageRepository
             Object[] row = results.next();
             p.setId(row[0].toString());
             p.setTitle("" + row[1]);
+            p.setTemplateId(((BigInteger)row[2]).longValue());
             result.add(p);
          }
          return result;

--- a/catalogue/src/main/java/org/giavacms/catalogue/controller/CatalogueConfigurationController.java
+++ b/catalogue/src/main/java/org/giavacms/catalogue/controller/CatalogueConfigurationController.java
@@ -13,33 +13,51 @@ import org.giavacms.common.annotation.OwnRepository;
 import org.giavacms.common.annotation.ViewPage;
 import org.giavacms.common.controller.AbstractLazyController;
 
-
 @Named
 @SessionScoped
 public class CatalogueConfigurationController extends
-		AbstractLazyController<CatalogueConfiguration> {
+         AbstractLazyController<CatalogueConfiguration>
+{
 
-	private static final long serialVersionUID = 1L;
+   private static final long serialVersionUID = 1L;
 
-	// --------------------------------------------------------
-	@BackPage
-	public static String BACK = "/private/administration.xhtml";
-	@ViewPage
-	@ListPage
-	@EditPage
-	public static String LIST = "/private/catalogue/configuration.xhtml";
+   // --------------------------------------------------------
+   @BackPage
+   public static String BACK = "/private/administration.xhtml";
+   @ViewPage
+   @ListPage
+   @EditPage
+   public static String LIST = "/private/catalogue/configuration.xhtml";
 
-	// ------------------------------------------------
+   // ------------------------------------------------
 
-	@Inject
-	@OwnRepository(CatalogueConfigurationRepository.class)
-	CatalogueConfigurationRepository catalogueConfigurationRepository;
+   @Inject
+   @OwnRepository(CatalogueConfigurationRepository.class)
+   CatalogueConfigurationRepository catalogueConfigurationRepository;
 
-	@Override
-	public CatalogueConfiguration getElement() {
-		if (super.getElement() == null)
-			setElement(catalogueConfigurationRepository.load());
-		return super.getElement();
-	}
+   @Override
+   public CatalogueConfiguration getElement()
+   {
+      if (super.getElement() == null)
+         setElement(catalogueConfigurationRepository.load());
+      return super.getElement();
+   }
+
+   @Override
+   public String update()
+   {
+      if (super.update() == null)
+      {
+         return null;
+      }
+      return backPage();
+   }
+
+   @Override
+   public String reset()
+   {
+      super.reset();
+      return backPage();
+   }
 
 }

--- a/catalogue/src/main/java/org/giavacms/catalogue/repository/ProductRepository.java
+++ b/catalogue/src/main/java/org/giavacms/catalogue/repository/ProductRepository.java
@@ -394,6 +394,7 @@ public class ProductRepository extends AbstractPageRepository<Product>
             if (template_impl_id instanceof BigInteger)
             {
                product.getTemplate().setId(((BigInteger) template_impl_id).longValue());
+               product.setTemplateId(((BigInteger) template_impl_id).longValue());
             }
             else
             {

--- a/catalogue/src/main/resources/META-INF/resources/private/catalogue/category/list.xhtml
+++ b/catalogue/src/main/resources/META-INF/resources/private/catalogue/category/list.xhtml
@@ -74,7 +74,7 @@
 							</p:cellEditor>
 						</p:column>
 
-						<p:column width="100">
+						<p:column width="100" >
 							<f:facet name="header">ordine</f:facet>
 							<p:cellEditor>
 								<f:facet name="output">
@@ -86,7 +86,7 @@
 							</p:cellEditor>
 						</p:column>
 
-						<p:column width="200">
+						<p:column width="200" >
 							<f:facet name="header">pagina di base</f:facet>
 							<p:cellEditor>
 								<f:facet name="output">

--- a/richcontent/src/main/java/org/giavacms/richcontent/repository/RichContentRepository.java
+++ b/richcontent/src/main/java/org/giavacms/richcontent/repository/RichContentRepository.java
@@ -582,6 +582,7 @@ public class RichContentRepository extends AbstractPageRepository<RichContent>
             if (template_impl_id instanceof BigInteger)
             {
                richContent.getTemplate().setId(((BigInteger) template_impl_id).longValue());
+               richContent.setTemplateId(((BigInteger) template_impl_id).longValue());
             }
             else
             {


### PR DESCRIPTION
in line editing does not work, yet.

this is due to a bug in how p:dataTable + h:selectOneMenu treats the base page column (and it affects also richContent and similar data tables with base-page in line modification).

Tried to upgrade to prime 3.4.2 but it wrecks so many other pages...

Tried to use p:selectOneMenu's instead of h:selectOneMenu's but they show up empty or break the rowEdit toggle behaviour

stack trace results say:

08:50:41,050 INFO  [javax.enterprise.resource.webcontainer.jsf.context](http--0.0.0.0-8080-1) java.lang.NumberFormatException: null: java.lang.NumberFormatException: null
        at java.lang.Integer.parseInt(Integer.java:417) [rt.jar:1.6.0_37]
        at java.lang.Integer.parseInt(Integer.java:499) [rt.jar:1.6.0_37]
        at org.primefaces.component.datatable.DataTable.queueEvent(DataTable.java:609) [primefaces-3.3.jar:]
        at org.primefaces.component.behavior.ajax.AjaxBehaviorRenderer.decode(AjaxBehaviorRenderer.java:42) [primefaces-3.3.jar:]
        at javax.faces.component.behavior.ClientBehaviorBase.decode(ClientBehaviorBase.java:132) [jboss-jsf-api_2.1_spec-2.0.1.Final.jar:2.0.1.Final]
        at org.primefaces.renderkit.CoreRenderer.decodeBehaviors(CoreRenderer.java:328) [primefaces-3.3.jar:]
        at org.primefaces.component.datatable.DataTableRenderer.decode(DataTableRenderer.java:79) [primefaces-3.3.jar:]
        at javax.faces.component.UIComponentBase.decode(UIComponentBase.java:787) [jboss-jsf-api_2.1_spec-2.0.1.Final.jar:2.0.1.Final]
        at javax.faces.component.UIData.processDecodes(UIData.java:1162) [jboss-jsf-api_2.1_spec-2.0.1.Final.jar:2.0.1.Final]
        at org.primefaces.component.datatable.DataTable.processDecodes(DataTable.java:554) [primefaces-3.3.jar:]
        at com.sun.faces.context.PartialViewContextImpl$PhaseAwareVisitCallback.visit(PartialViewContextImpl.java:506) [jsf-impl-2.1.7-jbossorg-2.jar:]
        at com.sun.faces.component.visit.PartialVisitContext.invokeVisitCallback(PartialVisitContext.java:183) [jsf-impl-2.1.7-jbossorg-2.jar:]
        at javax.faces.component.UIData.visitTree(UIData.java:1411) [jboss-jsf-api_2.1_spec-2.0.1.Final.jar:2.0.1.Final]
        at javax.faces.component.UIComponent.visitTree(UIComponent.java:1623) [jboss-jsf-api_2.1_spec-2.0.1.Final.jar:2.0.1.Final]
        at javax.faces.component.UIComponent.visitTree(UIComponent.java:1623) [jboss-jsf-api_2.1_spec-2.0.1.Final.jar:2.0.1.Final]
        at javax.faces.component.UIForm.visitTree(UIForm.java:362) [jboss-jsf-api_2.1_spec-2.0.1.Final.jar:2.0.1.Final]
        at javax.faces.component.UIComponent.visitTree(UIComponent.java:1623) [jboss-jsf-api_2.1_spec-2.0.1.Final.jar:2.0.1.Final]
        at javax.faces.component.UIComponent.visitTree(UIComponent.java:1623) [jboss-jsf-api_2.1_spec-2.0.1.Final.jar:2.0.1.Final]
        at javax.faces.component.UIComponent.visitTree(UIComponent.java:1623) [jboss-jsf-api_2.1_spec-2.0.1.Final.jar:2.0.1.Final]
        at com.sun.faces.context.PartialViewContextImpl.processComponents(PartialViewContextImpl.java:376) [jsf-impl-2.1.7-jbossorg-2.jar:]
        at com.sun.faces.context.PartialViewContextImpl.processPartial(PartialViewContextImpl.java:252) [jsf-impl-2.1.7-jbossorg-2.jar:]
        at javax.faces.context.PartialViewContextWrapper.processPartial(PartialViewContextWrapper.java:183) [jboss-jsf-api_2.1_spec-2.0.1.Final.jar:2.0.1.Final]
        at javax.faces.component.UIViewRoot.processDecodes(UIViewRoot.java:931) [jboss-jsf-api_2.1_spec-2.0.1.Final.jar:2.0.1.Final]
        at com.sun.faces.lifecycle.ApplyRequestValuesPhase.execute(ApplyRequestValuesPhase.java:78) [jsf-impl-2.1.7-jbossorg-2.jar:]
        at com.sun.faces.lifecycle.Phase.doPhase(Phase.java:101) [jsf-impl-2.1.7-jbossorg-2.jar:]
        at com.sun.faces.lifecycle.LifecycleImpl.execute(LifecycleImpl.java:118) [jsf-impl-2.1.7-jbossorg-2.jar:]
        at javax.faces.webapp.FacesServlet.service(FacesServlet.java:593) [jboss-jsf-api_2.1_spec-2.0.1.Final.jar:2.0.1.Final]
